### PR TITLE
#2 fix: fix broken navigation links on doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 <!-- PROJECT LOGO -->
 <div align="center">
-  <a href="https://github.com/0xAbdulKhalid/Odin-Project-Workspace">
     <img src="./assets/images/calculator.png" alt="Logo" width="150">
-  </a>
+</div>
 
 <h3 align="center">Calculator</h3>
 
   <p align="center">
-    For Simple Calculations
+    Let's perform arithmetic operations on numbers
     <br />
     <br />
-    <a href="https://0xabdulkhalid.github.io/Odin-Project-Workspace/Calculator/">View Demo</a>
+    <a href="https://0xabdulkhalid.github.io/calculator/" target="_blank">View Demo</a>
     ·
-    <a href="https://github.com/0xAbdulKhalid/Odin-Project-Workspace/issues">Report Bug</a>
+    <a href="https://github.com/0xabdulkhalid/calculator/issues" target="_blank">Report Bug</a>
     ·
-    <a href="https://github.com/0xAbdulKhalid/Odin-Project-Workspace/issues">Request Feature</a>
+    <a href="https://github.com/0xabdulkhalid/calculator/issues" target="_blank">Request Feature</a>
   </p>
 </div>
 
@@ -27,34 +26,8 @@
  <img src="./assets/images/preview.png">
 </div>
 
-
-### Built With
-
-- ![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white)   
-- ![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white)   
-- ![JavaScript](https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E)
-
-### Tools Used
-
-- ![Google](https://img.shields.io/badge/google-4285F4?style=for-the-badge&logo=google&logoColor=white)   
-- ![Shell Script](https://img.shields.io/badge/Terminal-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white)  
-- ![Visual Studio Code](https://img.shields.io/badge/Visual%20Studio%20Code-0078d7.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white)  
-- ![Arch](https://img.shields.io/badge/Arch%20Linux-1793D1?logo=arch-linux&logoColor=fff&style=for-the-badge)
-
-<br>
-
-## Features
-
-- A Simple Calculator which is built with Modern Javascript practices  
-- It can evaluate expressions for Multiplication, Division, Subraction, Addition & Modulo Division 
-- Clean UI for better visuals
-- Responsive for both Desktop & Mobile
-
-<br>
-
 <!-- USAGE EXAMPLES -->
 ## Usage
-
 - <details> <summary>For Mobile</summary>
 
   - ### General
@@ -75,6 +48,14 @@
     - `'C' Key`:  Clears the Display
     - `Operation Keys`: Operates with operands
 </details>
+<br>
+
+## Features
+
+- A Simple Calculator which is built with Modern Javascript practices  
+- It can evaluate expressions for Multiplication, Division, Subraction, Addition & Modulo Division 
+- Comes with user friendly UI & UX
+- Responsive for both Desktop & Mobile
 
 <br>
 
@@ -91,16 +72,34 @@
 
 ## What I learned
 
-* Better knowledge and it's practical usability of **Javascript**
+* Usability of Javascript's **ES6 Classes**
+* Utilization of `transitionend` event for animating buttons without hassle
 * Learned to add **keyboard support** with event listeners
 * A lot of minor things
+
+<br>
+
+### Built With
+
+- ![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white)   
+- ![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white)   
+- ![JavaScript](https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E)
+
+<br>
+
+### Tools Used
+
+- ![Google](https://img.shields.io/badge/google-4285F4?style=for-the-badge&logo=google&logoColor=white)   
+- ![Shell Script](https://img.shields.io/badge/Terminal-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white)  
+- ![Visual Studio Code](https://img.shields.io/badge/Visual%20Studio%20Code-0078d7.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white)  
+- ![Arch](https://img.shields.io/badge/Arch%20Linux-1793D1?logo=arch-linux&logoColor=fff&style=for-the-badge)
 
 <br>
 
 <!-- ACKNOWLEDGMENTS -->
 ## Acknowledgments
 
-* Inspiration by [The Odin Project]()
+* Inspiration by [The Odin Project](https://www.theodinproject.com/)
 
 <br>
 
@@ -114,10 +113,18 @@
 <!-- CONTACT -->
 ## Author
 
-<div align="center">
+<div align=center>
 
 <a href="https://linkedin.com/in/0xabdulkhalid" target="_blank">
-<img src="https://img.shields.io/badge/linkedin:  0xabdulkhalid-%2300acee.svg?color=405DE6&style=for-the-badge&logo=linkedin&logoColor=white" alt=linkedin style="margin-bottom: 5px;"/>
+	<img src="https://img.shields.io/badge/linkedin-%2300acee.svg?color=405DE6&style=for-the-badge&logo=linkedin&logoColor=white" alt=Linkedin>
+</a>&nbsp;&nbsp;&nbsp;
+<a href="mailto:0xabdulkhalid@gmail.com" target="_blank">
+	<img src="https://img.shields.io/badge/0xabdulkhalid@gmail.com-D14836?style=for-the-badge&logo=gmail&logoColor=white" alt="Frontend-Mentor">
+</a> &nbsp;&nbsp;&nbsp;
+<a href="https://www.0xabdulkhalid.ml" target="_blank">
+	<img src="https://img.shields.io/badge/website-0F8A79?style=for-the-badge&logo=About.me&logoColor=white" alt="Personal Website">
 </a>
 
 </div>
+
+<br>


### PR DESCRIPTION
### Brief statement about how broken links occured
- Actually this project is seperated from old repository named [odin-project-workspace](https://github.com/0xabdulkhalid/Odin-Project-Workspace)
- Eventually after cloning `calculator` the navigation links in `readme` were pointing to old repository which causes broken navigation

### Now it's been fixed by updating those links to current repository